### PR TITLE
support ksi and MPa in ui

### DIFF
--- a/lib/data/default_order.dart
+++ b/lib/data/default_order.dart
@@ -194,6 +194,8 @@ const Map<PROPERTYX, List<dynamic>> defaultUnitsOrder = {
     PRESSURE.torr,
     PRESSURE.inchOfMercury,
     PRESSURE.hectoPascal,
+    // PRESSURE.ksi,
+    // PRESSURE.megaPascal
   ],
   PROPERTYX.energy: [
     ENERGY.kilowattHours,

--- a/lib/data/property_unit_maps.dart
+++ b/lib/data/property_unit_maps.dart
@@ -240,6 +240,8 @@ Map<PROPERTYX, Map<dynamic, String>> getUnitUiMap(BuildContext context) {
       PRESSURE.torr: l10n.torr,
       PRESSURE.inchOfMercury: l10n.inchesOfMercury,
       PRESSURE.hectoPascal: l10n.hectoPascal,
+      // PRESSURE.ksi: l10n.ksi,
+      // PRESSURE.megaPascal: l10n.megaPascal,
     },
     PROPERTYX.energy: {
       ENERGY.kilowattHours: l10n.kilowattHour,

--- a/packages/translations/lib/l10n/app_en.arb
+++ b/packages/translations/lib/l10n/app_en.arb
@@ -206,6 +206,8 @@
   "hectoPascal": "Hectopascal",
   "inchesOfMercury": "Inches of mercury",
   "kiloPascal": "Kilopascal",
+  "ksi": "Kilopounds per square inch",
+  "megaPascal": "Megapascal",
 
   "joule": "Joule",
   "calories": "Calories",


### PR DESCRIPTION
Dependent on https://github.com/ferraridamiano/units_converter/pull/56

Kept separate from https://github.com/ferraridamiano/ConverterNOW/pull/345 but I can put it in one