### PR TITLE
fix: mjs content type header

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ FROM nginx:1.28-alpine3.21-slim
 
 COPY --from=builder /app/build/web /usr/share/nginx/html
 
+# Workaround, remove once https://github.com/nginx/nginx/pull/448 has been merged
 RUN sed -i 's|application/javascript[[:space:]]\+js;|application/javascript       js mjs;|' /etc/nginx/mime.types
 
 EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,8 @@ FROM nginx:1.28-alpine3.21-slim
 
 COPY --from=builder /app/build/web /usr/share/nginx/html
 
+RUN sed -i 's|application/javascript[[:space:]]\+js;|application/javascript       js mjs;|' /etc/nginx/mime.types
+
 EXPOSE 80
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \


### PR DESCRIPTION
Solves #344 

Because nginx does not yet support the mjs files with the correct Content-Type header (https://github.com/nginx/nginx/pull/448).